### PR TITLE
docs: 命令`go build .`构建产物名字为项目名即paopao-ce

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ PaoPao主要由以下优秀的开源项目/工具构建
 3. 编译后端
     ```sh
     go mod download
-    go build .
+    go build -o paopao-api .
     ```
 4. 启动后端
     ```sh


### PR DESCRIPTION
docs: 命令`go build .`构建产物名字为项目名即paopao-ce，故调整编译命令为`go build -o paopao-api .`