### PR TITLE
add runtime config to adjust app feature

### DIFF
--- a/config.yaml.sample
+++ b/config.yaml.sample
@@ -10,6 +10,8 @@ App: # APP基础设置项
   SmsJuheTplVal: "#code#=%d&#m#=%d"
   AlipayAppID:
   AlipayPrivateKey:
+Runtime: # App运行时功能调节
+  DisablePhoneVerify: False # 禁止绑定手机号码时验证短信验证码，为true时任意验证码都可以通过验证
 Server: # 服务设置
   RunMode: debug
   HttpIp: 0.0.0.0

--- a/global/setting.go
+++ b/global/setting.go
@@ -10,6 +10,7 @@ import (
 var (
 	ServerSetting   *setting.ServerSettingS
 	AppSetting      *setting.AppSettingS
+	RuntimeSetting  *setting.RuntimeSettingS
 	DatabaseSetting *setting.DatabaseSettingS
 	RedisSetting    *setting.RedisSettingS
 	SearchSetting   *setting.SearchSettingS

--- a/init.go
+++ b/init.go
@@ -41,6 +41,10 @@ func setupSetting() error {
 	if err != nil {
 		return err
 	}
+	err = setting.ReadSection("Runtime", &global.RuntimeSetting)
+	if err != nil {
+		return err
+	}
 	err = setting.ReadSection("Log", &global.LoggerSetting)
 	if err != nil {
 		return err

--- a/internal/routers/api/user.go
+++ b/internal/routers/api/user.go
@@ -248,11 +248,12 @@ func BindUserPhone(c *gin.Context) {
 	}
 
 	// 验证短信验证码
-	err := svc.CheckPhoneCaptcha(param.Phone, param.Captcha)
-	if err != nil {
-		global.Logger.Errorf("svc.CheckPhoneCaptcha err: %v\n", err)
-		response.ToErrorResponse(err)
-		return
+	if !global.RuntimeSetting.DisablePhoneVerify {
+		if err := svc.CheckPhoneCaptcha(param.Phone, param.Captcha); err != nil {
+			global.Logger.Errorf("svc.CheckPhoneCaptcha err: %v\n", err)
+			response.ToErrorResponse(err)
+			return
+		}
 	}
 
 	// 执行绑定

--- a/pkg/setting/settting.go
+++ b/pkg/setting/settting.go
@@ -51,6 +51,10 @@ type AppSettingS struct {
 	AlipayPrivateKey      string
 }
 
+type RuntimeSettingS struct {
+	DisablePhoneVerify bool
+}
+
 type SearchSettingS struct {
 	ZincHost     string
 	ZincIndex    string


### PR DESCRIPTION
* add `Runtime` section of global configure in config.yaml to adjust app feature in serve
* support disable phone verify in bind phone number when `Runtime.DisablePhoneVerify: True` on config.yaml

为什么添加Runtime配置选项？
方便调节app运行时提供哪些功能。

为什么支持禁止绑定手机时 手机号码验证？
额～这个～ 在开发环境，暂时没有聚合平台账号，所以发不了验证码短信，所以没法在本地环境本地测试其他功能，比如发泡泡啥的。 开发环境完全可以不用验证手机号码完成手机绑定，该补丁提供这个机制支持开发环境免去手机号码验证直接绑定手机号码。