### PR TITLE
optimize code in internal/service pacakge

### DIFF
--- a/init.go
+++ b/init.go
@@ -8,8 +8,10 @@ import (
 	"github.com/go-redis/redis/v8"
 	"github.com/rocboss/paopao-ce/global"
 	"github.com/rocboss/paopao-ce/internal/model"
+	"github.com/rocboss/paopao-ce/internal/service"
 	"github.com/rocboss/paopao-ce/pkg/logger"
 	"github.com/rocboss/paopao-ce/pkg/setting"
+	"github.com/rocboss/paopao-ce/pkg/zinc"
 )
 
 func init() {
@@ -25,6 +27,8 @@ func init() {
 	if err != nil {
 		log.Fatalf("init.setupDBEngine err: %v", err)
 	}
+	client := zinc.NewClient(global.SearchSetting)
+	service.Initialize(global.DBEngine, client)
 }
 
 func setupSetting() error {

--- a/internal/routers/api/comment.go
+++ b/internal/routers/api/comment.go
@@ -11,15 +11,13 @@ import (
 )
 
 func GetPostComments(c *gin.Context) {
-
 	postID := convert.StrTo(c.Query("id")).MustInt64()
 	response := app.NewResponse(c)
 
-	svc := service.New(c)
-	contents, totalRows, err := svc.GetPostComments(postID, "id ASC", 0, 0)
+	contents, totalRows, err := service.GetPostComments(postID, "id ASC", 0, 0)
 
 	if err != nil {
-		global.Logger.Errorf("svc.GetPostComments err: %v\n", err)
+		global.Logger.Errorf("service.GetPostComments err: %v\n", err)
 		response.ToErrorResponse(errcode.GetCommentsFailed)
 		return
 	}
@@ -38,14 +36,13 @@ func CreatePostComment(c *gin.Context) {
 	}
 
 	userID, _ := c.Get("UID")
-	svc := service.New(c)
-	comment, err := svc.CreatePostComment(userID.(int64), param)
+	comment, err := service.CreatePostComment(c, userID.(int64), param)
 
 	if err != nil {
 		if err == errcode.MaxCommentCount {
 			response.ToErrorResponse(errcode.MaxCommentCount)
 		} else {
-			global.Logger.Errorf("svc.CreatePostComment err: %v\n", err)
+			global.Logger.Errorf("service.CreatePostComment err: %v\n", err)
 			response.ToErrorResponse(errcode.CreateCommentFailed)
 		}
 		return
@@ -64,11 +61,10 @@ func DeletePostComment(c *gin.Context) {
 		return
 	}
 	user, _ := c.Get("USER")
-	svc := service.New(c)
 
-	comment, err := svc.GetPostComment(param.ID)
+	comment, err := service.GetPostComment(param.ID)
 	if err != nil {
-		global.Logger.Errorf("svc.GetPostComment err: %v\n", err)
+		global.Logger.Errorf("service.GetPostComment err: %v\n", err)
 		response.ToErrorResponse(errcode.GetCommentFailed)
 		return
 	}
@@ -79,9 +75,9 @@ func DeletePostComment(c *gin.Context) {
 	}
 
 	// 执行删除
-	err = svc.DeletePostComment(comment)
+	err = service.DeletePostComment(comment)
 	if err != nil {
-		global.Logger.Errorf("svc.DeletePostComment err: %v\n", err)
+		global.Logger.Errorf("service.DeletePostComment err: %v\n", err)
 		response.ToErrorResponse(errcode.DeleteCommentFailed)
 		return
 	}
@@ -99,11 +95,10 @@ func CreatePostCommentReply(c *gin.Context) {
 		return
 	}
 	user, _ := c.Get("USER")
-	svc := service.New(c)
 
-	comment, err := svc.CreatePostCommentReply(param.CommentID, param.Content, user.(*model.User).ID, param.AtUserID)
+	comment, err := service.CreatePostCommentReply(c, param.CommentID, param.Content, user.(*model.User).ID, param.AtUserID)
 	if err != nil {
-		global.Logger.Errorf("svc.CreatePostCommentReply err: %v\n", err)
+		global.Logger.Errorf("service.CreatePostCommentReply err: %v\n", err)
 		response.ToErrorResponse(errcode.CreateReplyFailed)
 		return
 	}
@@ -122,11 +117,10 @@ func DeletePostCommentReply(c *gin.Context) {
 	}
 
 	user, _ := c.Get("USER")
-	svc := service.New(c)
 
-	reply, err := svc.GetPostCommentReply(param.ID)
+	reply, err := service.GetPostCommentReply(param.ID)
 	if err != nil {
-		global.Logger.Errorf("svc.GetPostCommentReply err: %v\n", err)
+		global.Logger.Errorf("service.GetPostCommentReply err: %v\n", err)
 		response.ToErrorResponse(errcode.GetReplyFailed)
 		return
 	}
@@ -137,9 +131,9 @@ func DeletePostCommentReply(c *gin.Context) {
 	}
 
 	// 执行删除
-	err = svc.DeletePostCommentReply(reply)
+	err = service.DeletePostCommentReply(reply)
 	if err != nil {
-		global.Logger.Errorf("svc.DeletePostCommentReply err: %v\n", err)
+		global.Logger.Errorf("service.DeletePostCommentReply err: %v\n", err)
 		response.ToErrorResponse(errcode.DeleteCommentFailed)
 		return
 	}

--- a/internal/routers/api/home.go
+++ b/internal/routers/api/home.go
@@ -30,12 +30,11 @@ func Version(c *gin.Context) {
 
 func SyncSearchIndex(c *gin.Context) {
 	response := app.NewResponse(c)
-	svc := service.New(c)
 
 	user, _ := c.Get("USER")
 
 	if user.(*model.User).IsAdmin {
-		go svc.PushPostsToSearch()
+		go service.PushPostsToSearch(c)
 	}
 
 	response.ToResponse(nil)
@@ -77,7 +76,6 @@ func PostCaptcha(c *gin.Context) {
 		response.ToErrorResponse(errcode.InvalidParams.WithDetails(errs.Errors()...))
 		return
 	}
-	svc := service.New(c)
 
 	// 验证图片验证码
 	if res, err := global.Redis.Get(c.Request.Context(), "PaoPaoCaptcha:"+param.ImgCaptchaID).Result(); err != nil || res != param.ImgCaptcha {
@@ -92,7 +90,7 @@ func PostCaptcha(c *gin.Context) {
 		return
 	}
 
-	err := svc.SendPhoneCaptcha(param.Phone)
+	err := service.SendPhoneCaptcha(c, param.Phone)
 	if err != nil {
 		global.Logger.Errorf("app.SendPhoneCaptcha errs: %v", errs)
 		response.ToErrorResponse(errcode.GetPhoneCaptchaError)

--- a/internal/routers/api/message.go
+++ b/internal/routers/api/message.go
@@ -16,9 +16,8 @@ func GetUnreadMsgCount(c *gin.Context) {
 	if u, exists := c.Get("USER"); exists {
 		user = u.(*model.User)
 	}
-	svc := service.New(c)
 
-	count, _ := svc.GetUnreadCount(user.ID)
+	count, _ := service.GetUnreadCount(user.ID)
 
 	response.ToResponse(gin.H{
 		"count": count,
@@ -29,11 +28,10 @@ func GetMessages(c *gin.Context) {
 	response := app.NewResponse(c)
 
 	userID, _ := c.Get("UID")
-	svc := service.New(c)
-	messages, totalRows, err := svc.GetMessages(userID.(int64), (app.GetPage(c)-1)*app.GetPageSize(c), app.GetPageSize(c))
+	messages, totalRows, err := service.GetMessages(userID.(int64), (app.GetPage(c)-1)*app.GetPageSize(c), app.GetPageSize(c))
 
 	if err != nil {
-		global.Logger.Errorf("svc.GetMessages err: %v\n", err)
+		global.Logger.Errorf("service.GetMessages err: %v\n", err)
 		response.ToErrorResponse(errcode.GetMessagesFailed)
 		return
 	}
@@ -52,10 +50,9 @@ func ReadMessage(c *gin.Context) {
 	}
 
 	userID, _ := c.Get("UID")
-	svc := service.New(c)
-	err := svc.ReadMessage(param.ID, userID.(int64))
+	err := service.ReadMessage(param.ID, userID.(int64))
 	if err != nil {
-		global.Logger.Errorf("svc.ReadMessage err: %v\n", err)
+		global.Logger.Errorf("service.ReadMessage err: %v\n", err)
 		response.ToErrorResponse(errcode.ReadMessageFailed)
 		return
 	}
@@ -81,8 +78,7 @@ func SendUserWhisper(c *gin.Context) {
 		return
 	}
 
-	svc := service.New(c)
-	_, err := svc.CreateWhisper(&model.Message{
+	_, err := service.CreateWhisper(c, &model.Message{
 		SenderUserID:   userID.(int64),
 		ReceiverUserID: param.UserID,
 		Type:           model.MESSAGE_WHISPER,
@@ -91,7 +87,7 @@ func SendUserWhisper(c *gin.Context) {
 	})
 
 	if err != nil {
-		global.Logger.Errorf("svc.CreateWhisper err: %v\n", err)
+		global.Logger.Errorf("service.CreateWhisper err: %v\n", err)
 
 		if err == errcode.TooManyWhisperNum {
 			response.ToErrorResponse(errcode.TooManyWhisperNum)

--- a/internal/service/attachment.go
+++ b/internal/service/attachment.go
@@ -2,6 +2,6 @@ package service
 
 import "github.com/rocboss/paopao-ce/internal/model"
 
-func (svc *Service) CreateAttachment(attachment *model.Attachment) (*model.Attachment, error) {
-	return svc.dao.CreateAttachment(attachment)
+func CreateAttachment(attachment *model.Attachment) (*model.Attachment, error) {
+	return myDao.CreateAttachment(attachment)
 }

--- a/internal/service/avatar.go
+++ b/internal/service/avatar.go
@@ -58,7 +58,7 @@ var defaultAvatars = []string{
 	"https://assets.paopao.info/public/avatar/default/abigail.png",
 }
 
-func (s *Service) GetRandomAvatar() string {
+func GetRandomAvatar() string {
 	rand.Seed(time.Now().UnixMicro())
 	return defaultAvatars[rand.Intn(len(defaultAvatars))]
 }

--- a/internal/service/comment.go
+++ b/internal/service/comment.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gin-gonic/gin"
 	"github.com/rocboss/paopao-ce/global"
 	"github.com/rocboss/paopao-ce/internal/model"
 	"github.com/rocboss/paopao-ce/pkg/errcode"
@@ -28,12 +29,12 @@ type ReplyDelReq struct {
 	ID int64 `json:"id" binding:"required"`
 }
 
-func (svc *Service) GetPostComments(postID int64, sort string, offset, limit int) ([]*model.CommentFormated, int64, error) {
+func GetPostComments(postID int64, sort string, offset, limit int) ([]*model.CommentFormated, int64, error) {
 	conditions := &model.ConditionsT{
 		"post_id": postID,
 		"ORDER":   sort,
 	}
-	comments, err := svc.dao.GetComments(conditions, offset, limit)
+	comments, err := myDao.GetComments(conditions, offset, limit)
 
 	if err != nil {
 		return nil, 0, err
@@ -46,17 +47,17 @@ func (svc *Service) GetPostComments(postID int64, sort string, offset, limit int
 		commentIDs = append(commentIDs, comment.ID)
 	}
 
-	users, err := svc.dao.GetUsersByIDs(userIDs)
+	users, err := myDao.GetUsersByIDs(userIDs)
 	if err != nil {
 		return nil, 0, err
 	}
 
-	contents, err := svc.dao.GetCommentContentsByIDs(commentIDs)
+	contents, err := myDao.GetCommentContentsByIDs(commentIDs)
 	if err != nil {
 		return nil, 0, err
 	}
 
-	replies, err := svc.dao.GetCommentRepliesByID(commentIDs)
+	replies, err := myDao.GetCommentRepliesByID(commentIDs)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -84,14 +85,14 @@ func (svc *Service) GetPostComments(postID int64, sort string, offset, limit int
 	}
 
 	// 获取总量
-	totalRows, _ := svc.dao.GetCommentCount(conditions)
+	totalRows, _ := myDao.GetCommentCount(conditions)
 
 	return commentsFormated, totalRows, nil
 }
 
-func (svc *Service) CreatePostComment(userID int64, param CommentCreationReq) (*model.Comment, error) {
+func CreatePostComment(ctx *gin.Context, userID int64, param CommentCreationReq) (*model.Comment, error) {
 	// 加载Post
-	post, err := svc.dao.GetPostByID(param.PostID)
+	post, err := myDao.GetPostByID(param.PostID)
 
 	if err != nil {
 		return nil, err
@@ -100,14 +101,14 @@ func (svc *Service) CreatePostComment(userID int64, param CommentCreationReq) (*
 	if post.CommentCount >= global.AppSetting.MaxCommentCount {
 		return nil, errcode.MaxCommentCount
 	}
-	ip := svc.ctx.ClientIP()
+	ip := ctx.ClientIP()
 	comment := &model.Comment{
 		PostID: post.ID,
 		UserID: userID,
 		IP:     ip,
 		IPLoc:  util.GetIPLoc(ip),
 	}
-	comment, err = svc.dao.CreateComment(comment)
+	comment, err = myDao.CreateComment(comment)
 	if err != nil {
 		return nil, err
 	}
@@ -127,21 +128,21 @@ func (svc *Service) CreatePostComment(userID int64, param CommentCreationReq) (*
 			Type:      item.Type,
 			Sort:      item.Sort,
 		}
-		svc.dao.CreateCommentContent(postContent)
+		myDao.CreateCommentContent(postContent)
 	}
 
 	// 更新Post回复数
 	post.CommentCount++
 	post.LatestRepliedOn = time.Now().Unix()
-	svc.dao.UpdatePost(post)
+	myDao.UpdatePost(post)
 
 	// 更新索引
-	go svc.PushPostToSearch(post)
+	go PushPostToSearch(post)
 
 	// 创建用户消息提醒
-	postMaster, err := svc.dao.GetUserByID(post.UserID)
+	postMaster, err := myDao.GetUserByID(post.UserID)
 	if err == nil && postMaster.ID != userID {
-		go svc.dao.CreateMessage(&model.Message{
+		go myDao.CreateMessage(&model.Message{
 			SenderUserID:   userID,
 			ReceiverUserID: postMaster.ID,
 			Type:           model.MESSAGE_COMMENT,
@@ -151,13 +152,13 @@ func (svc *Service) CreatePostComment(userID int64, param CommentCreationReq) (*
 		})
 	}
 	for _, u := range param.Users {
-		user, err := svc.dao.GetUserByUsername(u)
+		user, err := myDao.GetUserByUsername(u)
 		if err != nil || user.ID == userID || user.ID == postMaster.ID {
 			continue
 		}
 
 		// 创建消息提醒
-		go svc.dao.CreateMessage(&model.Message{
+		go myDao.CreateMessage(&model.Message{
 			SenderUserID:   userID,
 			ReceiverUserID: user.ID,
 			Type:           model.MESSAGE_COMMENT,
@@ -170,32 +171,32 @@ func (svc *Service) CreatePostComment(userID int64, param CommentCreationReq) (*
 	return comment, nil
 }
 
-func (svc *Service) GetPostComment(id int64) (*model.Comment, error) {
-	return svc.dao.GetCommentByID(id)
+func GetPostComment(id int64) (*model.Comment, error) {
+	return myDao.GetCommentByID(id)
 }
 
-func (svc *Service) DeletePostComment(comment *model.Comment) error {
+func DeletePostComment(comment *model.Comment) error {
 	// 加载post
-	post, err := svc.dao.GetPostByID(comment.PostID)
+	post, err := myDao.GetPostByID(comment.PostID)
 	if err == nil {
 		// 更新post回复数
 		post.CommentCount--
-		svc.dao.UpdatePost(post)
+		myDao.UpdatePost(post)
 	}
 
-	return svc.dao.DeleteComment(comment)
+	return myDao.DeleteComment(comment)
 }
 
-func (svc *Service) createPostPreHandler(commentID int64, userID, atUserID int64) (*model.Post, *model.Comment, int64,
+func createPostPreHandler(commentID int64, userID, atUserID int64) (*model.Post, *model.Comment, int64,
 	error) {
 	// 加载Comment
-	comment, err := svc.dao.GetCommentByID(commentID)
+	comment, err := myDao.GetCommentByID(commentID)
 	if err != nil {
 		return nil, nil, atUserID, err
 	}
 
 	// 加载comment的post
-	post, err := svc.dao.GetPostByID(comment.PostID)
+	post, err := myDao.GetPostByID(comment.PostID)
 	if err != nil {
 		return nil, nil, atUserID, err
 	}
@@ -210,7 +211,7 @@ func (svc *Service) createPostPreHandler(commentID int64, userID, atUserID int64
 
 	if atUserID > 0 {
 		// 检测目前用户是否存在
-		users, _ := svc.dao.GetUsersByIDs([]int64{atUserID})
+		users, _ := myDao.GetUsersByIDs([]int64{atUserID})
 		if len(users) == 0 {
 			atUserID = 0
 		}
@@ -219,18 +220,18 @@ func (svc *Service) createPostPreHandler(commentID int64, userID, atUserID int64
 	return post, comment, atUserID, nil
 }
 
-func (svc *Service) CreatePostCommentReply(commentID int64, content string, userID, atUserID int64) (*model.CommentReply, error) {
+func CreatePostCommentReply(ctx *gin.Context, commentID int64, content string, userID, atUserID int64) (*model.CommentReply, error) {
 	var (
 		post    *model.Post
 		comment *model.Comment
 		err     error
 	)
-	if post, comment, atUserID, err = svc.createPostPreHandler(commentID, userID, atUserID); err != nil {
+	if post, comment, atUserID, err = createPostPreHandler(commentID, userID, atUserID); err != nil {
 		return nil, err
 	}
 
 	// 创建评论
-	ip := svc.ctx.ClientIP()
+	ip := ctx.ClientIP()
 	reply := &model.CommentReply{
 		CommentID: commentID,
 		UserID:    userID,
@@ -240,7 +241,7 @@ func (svc *Service) CreatePostCommentReply(commentID int64, content string, user
 		IPLoc:     util.GetIPLoc(ip),
 	}
 
-	reply, err = svc.dao.CreateCommentReply(reply)
+	reply, err = myDao.CreateCommentReply(reply)
 	if err != nil {
 		return nil, err
 	}
@@ -248,15 +249,15 @@ func (svc *Service) CreatePostCommentReply(commentID int64, content string, user
 	// 更新Post回复数
 	post.CommentCount++
 	post.LatestRepliedOn = time.Now().Unix()
-	svc.dao.UpdatePost(post)
+	myDao.UpdatePost(post)
 
 	// 更新索引
-	go svc.PushPostToSearch(post)
+	go PushPostToSearch(post)
 
 	// 创建用户消息提醒
-	commentMaster, err := svc.dao.GetUserByID(comment.UserID)
+	commentMaster, err := myDao.GetUserByID(comment.UserID)
 	if err == nil && commentMaster.ID != userID {
-		go svc.dao.CreateMessage(&model.Message{
+		go myDao.CreateMessage(&model.Message{
 			SenderUserID:   userID,
 			ReceiverUserID: commentMaster.ID,
 			Type:           model.MESSAGE_REPLY,
@@ -266,9 +267,9 @@ func (svc *Service) CreatePostCommentReply(commentID int64, content string, user
 			ReplyID:        reply.ID,
 		})
 	}
-	postMaster, err := svc.dao.GetUserByID(post.UserID)
+	postMaster, err := myDao.GetUserByID(post.UserID)
 	if err == nil && postMaster.ID != userID && commentMaster.ID != postMaster.ID {
-		go svc.dao.CreateMessage(&model.Message{
+		go myDao.CreateMessage(&model.Message{
 			SenderUserID:   userID,
 			ReceiverUserID: postMaster.ID,
 			Type:           model.MESSAGE_REPLY,
@@ -279,10 +280,10 @@ func (svc *Service) CreatePostCommentReply(commentID int64, content string, user
 		})
 	}
 	if atUserID > 0 {
-		user, err := svc.dao.GetUserByID(atUserID)
+		user, err := myDao.GetUserByID(atUserID)
 		if err == nil && user.ID != userID && commentMaster.ID != user.ID && postMaster.ID != user.ID {
 			// 创建消息提醒
-			go svc.dao.CreateMessage(&model.Message{
+			go myDao.CreateMessage(&model.Message{
 				SenderUserID:   userID,
 				ReceiverUserID: user.ID,
 				Type:           model.MESSAGE_REPLY,
@@ -297,24 +298,24 @@ func (svc *Service) CreatePostCommentReply(commentID int64, content string, user
 	return reply, nil
 }
 
-func (svc *Service) GetPostCommentReply(id int64) (*model.CommentReply, error) {
-	return svc.dao.GetCommentReplyByID(id)
+func GetPostCommentReply(id int64) (*model.CommentReply, error) {
+	return myDao.GetCommentReplyByID(id)
 }
 
-func (svc *Service) DeletePostCommentReply(reply *model.CommentReply) error {
-	err := svc.dao.DeleteCommentReply(reply)
+func DeletePostCommentReply(reply *model.CommentReply) error {
+	err := myDao.DeleteCommentReply(reply)
 	if err != nil {
 		return err
 	}
 
 	// 加载Comment
-	comment, err := svc.dao.GetCommentByID(reply.CommentID)
+	comment, err := myDao.GetCommentByID(reply.CommentID)
 	if err != nil {
 		return err
 	}
 
 	// 加载comment的post
-	post, err := svc.dao.GetPostByID(comment.PostID)
+	post, err := myDao.GetPostByID(comment.PostID)
 	if err != nil {
 		return err
 	}
@@ -322,10 +323,10 @@ func (svc *Service) DeletePostCommentReply(reply *model.CommentReply) error {
 	// 更新Post回复数
 	post.CommentCount--
 	post.LatestRepliedOn = time.Now().Unix()
-	svc.dao.UpdatePost(post)
+	myDao.UpdatePost(post)
 
 	// 更新索引
-	go svc.PushPostToSearch(post)
+	go PushPostToSearch(post)
 
 	return nil
 }

--- a/internal/service/message.go
+++ b/internal/service/message.go
@@ -4,13 +4,14 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/gin-gonic/gin"
 	"github.com/rocboss/paopao-ce/global"
 	"github.com/rocboss/paopao-ce/internal/model"
 	"github.com/rocboss/paopao-ce/pkg/convert"
 	"github.com/rocboss/paopao-ce/pkg/errcode"
 )
 
-// 当日单用户私信总数限制（TODO 配置化、积分兑换等）
+// MAX_WHISPER_NUM_DAILY 当日单用户私信总数限制（TODO 配置化、积分兑换等）
 const MAX_WHISPER_NUM_DAILY = 20
 
 type ReadMessageReq struct {
@@ -21,37 +22,37 @@ type WhisperReq struct {
 	Content string `json:"content" binding:"required"`
 }
 
-// 创建私信
-func (svc *Service) CreateWhisper(msg *model.Message) (*model.Message, error) {
+// CreateWhisper 创建私信
+func CreateWhisper(c *gin.Context, msg *model.Message) (*model.Message, error) {
 	whisperKey := fmt.Sprintf("WhisperTimes:%d", msg.SenderUserID)
 
 	// 今日频次限制
-	if res, _ := global.Redis.Get(svc.ctx, whisperKey).Result(); convert.StrTo(res).MustInt() >= MAX_WHISPER_NUM_DAILY {
+	if res, _ := global.Redis.Get(c, whisperKey).Result(); convert.StrTo(res).MustInt() >= MAX_WHISPER_NUM_DAILY {
 		return nil, errcode.TooManyWhisperNum
 	}
 
 	// 创建私信
-	msg, err := svc.dao.CreateMessage(msg)
+	msg, err := myDao.CreateMessage(msg)
 	if err != nil {
 		return nil, err
 	}
 
 	// 写入当日（自然日）计数缓存
-	global.Redis.Incr(svc.ctx, whisperKey).Result()
+	global.Redis.Incr(c, whisperKey).Result()
 
 	currentTime := time.Now()
 	endTime := time.Date(currentTime.Year(), currentTime.Month(), currentTime.Day(), 23, 59, 59, 0, currentTime.Location())
-	global.Redis.Expire(svc.ctx, whisperKey, endTime.Sub(currentTime))
+	global.Redis.Expire(c, whisperKey, endTime.Sub(currentTime))
 
 	return msg, err
 }
 
-func (svc *Service) GetUnreadCount(userID int64) (int64, error) {
-	return svc.dao.GetUnreadCount(userID)
+func GetUnreadCount(userID int64) (int64, error) {
+	return myDao.GetUnreadCount(userID)
 }
-func (svc *Service) ReadMessage(id, userID int64) error {
+func ReadMessage(id, userID int64) error {
 	// 获取message
-	message, err := svc.dao.GetMessageByID(id)
+	message, err := myDao.GetMessageByID(id)
 	if err != nil {
 		return err
 	}
@@ -61,20 +62,20 @@ func (svc *Service) ReadMessage(id, userID int64) error {
 	}
 
 	// 已读消息
-	return svc.dao.ReadMessage(message)
+	return myDao.ReadMessage(message)
 }
 
-func (svc *Service) GetMessages(userID int64, offset, limit int) ([]*model.MessageFormated, int64, error) {
+func GetMessages(userID int64, offset, limit int) ([]*model.MessageFormated, int64, error) {
 	conditions := &model.ConditionsT{
 		"receiver_user_id": userID,
 		"ORDER":            "id DESC",
 	}
-	messages, err := svc.dao.GetMessages(conditions, offset, limit)
+	messages, err := myDao.GetMessages(conditions, offset, limit)
 
 	for _, mf := range messages {
 
 		if mf.SenderUserID > 0 {
-			user, err := svc.dao.GetUserByID(mf.SenderUserID)
+			user, err := myDao.GetUserByID(mf.SenderUserID)
 			if err == nil {
 				mf.SenderUser = user.Format()
 			}
@@ -82,17 +83,17 @@ func (svc *Service) GetMessages(userID int64, offset, limit int) ([]*model.Messa
 		}
 
 		if mf.PostID > 0 {
-			post, err := svc.GetPost(mf.PostID)
+			post, err := GetPost(mf.PostID)
 			if err == nil {
 				mf.Post = post
 				if mf.CommentID > 0 {
-					comment, err := svc.GetPostComment(mf.CommentID)
+					comment, err := GetPostComment(mf.CommentID)
 
 					if err == nil {
 						mf.Comment = comment
 
 						if mf.ReplyID > 0 {
-							reply, err := svc.GetPostCommentReply(mf.ReplyID)
+							reply, err := GetPostCommentReply(mf.ReplyID)
 							if err == nil {
 								mf.Reply = reply
 							}
@@ -108,7 +109,7 @@ func (svc *Service) GetMessages(userID int64, offset, limit int) ([]*model.Messa
 	}
 
 	// 获取总量
-	totalRows, _ := svc.dao.GetMessageCount(conditions)
+	totalRows, _ := myDao.GetMessageCount(conditions)
 
 	return messages, totalRows, nil
 }

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -1,26 +1,15 @@
 package service
 
 import (
-	"github.com/gin-gonic/gin"
-	"github.com/rocboss/paopao-ce/global"
 	"github.com/rocboss/paopao-ce/internal/dao"
 	"github.com/rocboss/paopao-ce/pkg/zinc"
+	"gorm.io/gorm"
 )
 
-type Service struct {
-	ctx *gin.Context
-	dao *dao.Dao
-}
+var (
+	myDao *dao.Dao
+)
 
-func New(ctx *gin.Context) Service {
-	svc := Service{ctx: ctx}
-	svc.dao = dao.New(global.DBEngine, &zinc.ZincClient{
-		ZincClientConfig: &zinc.ZincClientConfig{
-			ZincHost:     global.SearchSetting.ZincHost,
-			ZincUser:     global.SearchSetting.ZincUser,
-			ZincPassword: global.SearchSetting.ZincPassword,
-		},
-	})
-
-	return svc
+func Initialize(engine *gorm.DB, client *zinc.ZincClient) {
+	myDao = dao.New(engine, client)
 }

--- a/internal/service/sign.go
+++ b/internal/service/sign.go
@@ -8,7 +8,7 @@ import (
 	"github.com/rocboss/paopao-ce/pkg/util"
 )
 
-func (svc *Service) GetParamSign(param map[string]interface{}, secretKey string) string {
+func GetParamSign(param map[string]interface{}, secretKey string) string {
 	signRaw := ""
 
 	rawStrs := []string{}

--- a/pkg/zinc/zinc.go
+++ b/pkg/zinc/zinc.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/go-resty/resty/v2"
+	"github.com/rocboss/paopao-ce/pkg/setting"
 )
 
 type ZincClient struct {
@@ -49,14 +50,17 @@ type QueryResultT struct {
 	TimedOut bool         `json:"timed_out"`
 	Hits     *HitsResultT `json:"hits"`
 }
+
 type HitsResultT struct {
 	Total    *HitsResultTotalT `json:"total"`
 	MaxScore float64           `json:"max_score"`
 	Hits     []*HitItem        `json:"hits"`
 }
+
 type HitsResultTotalT struct {
 	Value int64 `json:"value"`
 }
+
 type HitItem struct {
 	Index     string      `json:"_index"`
 	Type      string      `json:"_type"`
@@ -64,6 +68,17 @@ type HitItem struct {
 	Score     float64     `json:"_score"`
 	Timestamp time.Time   `json:"@timestamp"`
 	Source    interface{} `json:"_source"`
+}
+
+// NewClient 获取ZincClient新实例
+func NewClient(conf *setting.SearchSettingS) *ZincClient {
+	return &ZincClient{
+		ZincClientConfig: &ZincClientConfig{
+			ZincHost:     conf.ZincHost,
+			ZincUser:     conf.ZincUser,
+			ZincPassword: conf.ZincPassword,
+		},
+	}
 }
 
 // 创建索引


### PR DESCRIPTION
* 优化service包的代码，直接导出功能函数

补丁主要优化什么?
```
// file: internal/routers/api/user.go

// 用户登录
func Login(c *gin.Context) {
    ...
    svc := service.New(c)
    user, err := svc.DoLogin(&param)
    ...
}

// 用户注册
func Register(c *gin.Context) {
    ...
    svc := service.New(c)
    err := svc.ValidUsername(param.Username)
    ...
    err = svc.CheckPassword(param.Password)
    ...
}

// 修改密码
func ChangeUserPassword(c *gin.Context) {
    ...
    svc := service.New(c)
    err := svc.CheckPassword(param.Password)
    ...
}
```
参考上面代码， 每次Restful请求都需要重新创建一个`service.Service`实例，但该实例包含的内容除了每次请求的 `c *gin.Context`外，其他内容都是不变的(结构内field 变量 `dao *dao.Dao` 其实每次创建都是用相同配置重新实例化一个对象)，也就是说，完全可以在对应的函数中按需传入`c *gin.Context`，不同功能函数内使用同一个不变的 `dao *dao.Dao` 完成业务逻辑。  
 
这个补丁的核心目标就是干掉 api函数里的 `svc := service.New(c)` 变成如下代码 :  
```
// file: internal/routers/api/user.go

// 用户登录
func Login(c *gin.Context) {
    ...
    user, err := service.DoLogin(&param)
    ...
}

// 用户注册
func Register(c *gin.Context) {
    ...
    err := service.ValidUsername(param.Username)
    ...
    err = service.CheckPassword(param.Password)
    ...
}

// 修改密码
func ChangeUserPassword(c *gin.Context) {
    ...
    err := service.CheckPassword(param.Password)
    ...
}
```
当并发量起来时，go的GC负载就是一个需要关注的问题，在热点路径上优化实例对象的创建是减轻GC负载行之有效的手段， 这里是优化服务internal/service的功能函数逻辑以函数方式直接导出取代以方法的方式导出，达到优化效果。

