### PR TITLE
desktop/tauri: remove submenu in window when not on MacOS platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ PaoPao主要由以下优秀的开源项目/工具构建
    yarn tauri build
    ```
    桌面端是使用[Rust](https://www.rust-lang.org/) + [tauri](https://github.com/tauri-apps/tauri)编写
-   的，需要Rust编译环境，具体安装指南请参考[https://www.rust-lang.org/tools/install](https://www.rust-lang.org/tools/install).
+   的，需要安装tauri的依赖，具体参考[https://tauri.studio/v1/guides/getting-started/prerequisites](https://tauri.studio/v1/guides/getting-started/prerequisites).
 
 ### 其他说明
 

--- a/web/src-tauri/Cargo.toml
+++ b/web/src-tauri/Cargo.toml
@@ -9,10 +9,10 @@ edition = "2021"
 rust-version = "1.57"
 
 [build-dependencies]
-tauri-build = { version = "1.0.0-rc.4", features = [] }
+tauri-build = { version = "1.0.0-rc.12", features = [] }
 
 [dependencies]
-tauri = { version = "1.0.0-rc.4", features = ["api-all"] }
+tauri = { version = "1.0.0-rc.12", features = ["api-all"] }
 
 [features]
 # by default Tauri runs in production mode

--- a/web/src-tauri/src/main.rs
+++ b/web/src-tauri/src/main.rs
@@ -3,15 +3,15 @@
     windows_subsystem = "windows"
 )]
 
-use tauri::api::shell;
-use tauri::{CustomMenuItem, Manager, Menu, MenuEntry, MenuItem, Submenu};
+#[cfg(target_os = "macos")]
+use tauri::{api::shell, CustomMenuItem, Manager, Menu, MenuEntry, MenuItem, Submenu};
 
 fn main() {
     let _ctx = tauri::generate_context!();
 
-    tauri::Builder::default()
+    #[cfg(target_os = "macos")]
+    let app = tauri::Builder::default()
         .menu(Menu::with_items([
-            #[cfg(target_os = "macos")]
             MenuEntry::Submenu(Submenu::new(
                 &_ctx.package_info().name,
                 Menu::with_items([
@@ -46,7 +46,11 @@ fn main() {
                 }
                 _ => {}
             }
-        })
-        .run(tauri::generate_context!())
+        });
+
+    #[cfg(not(target_os = "macos"))]
+    let app = tauri::Builder::default();
+
+    app.run(tauri::generate_context!())
         .expect("error while running tauri application");
 }


### PR DESCRIPTION
* remove submenu in window when not on MacOS platform

桌面端: 在Linux(Debian/Ubuntu/Fedora)、Windows平台下去掉菜单栏，界面看起来更加干净。