### PR TITLE
optimize #62 add command-line support for custom features

### DIFF
--- a/config.yaml.sample
+++ b/config.yaml.sample
@@ -36,11 +36,6 @@ JWT: # 鉴权加密
   Secret: 18a6413dc4fe394c66345ebe501b2f26
   Issuer: paopao-api
   Expire: 86400
-Search: # 搜索配置
-  ZincHost: http://127.0.0.1:4080
-  ZincIndex: paopao-data
-  ZincUser: admin
-  ZincPassword: admin
 Zinc: # Zinc搜索配置
   Host: http://127.0.0.1:4080
   Index: paopao-data

--- a/pkg/setting/seting_test.go
+++ b/pkg/setting/seting_test.go
@@ -33,6 +33,79 @@ func TestUseDefault(t *testing.T) {
 		"Sms":           true,
 		"Sms = SmsJuhe": true,
 		"SmsJuhe":       false,
+		"default":       true,
+	} {
+		if ok := features.CfgIf(exp); res != ok {
+			t.Errorf("CfgIf(%s) want %t got %t", exp, res, ok)
+		}
+	}
+}
+
+func TestUse(t *testing.T) {
+	suites := map[string][]string{
+		"default": {"Sms", "Alipay", "Zinc", "MySQL", "Redis", "AliOSS", "LogZinc"},
+		"develop": {"Zinc", "MySQL", "AliOSS", "LogFile"},
+		"slim":    {"Zinc", "MySQL", "Redis", "AliOSS", "LogFile"},
+	}
+	kv := map[string]string{
+		"sms": "SmsJuhe",
+	}
+	features := newFeatures(suites, kv)
+
+	features.Use([]string{"develop"}, true)
+	for _, data := range []struct {
+		key    string
+		expect string
+		exist  bool
+	}{
+		{"Sms", "", false},
+		{"Alipay", "", false},
+		{"Zinc", "", true},
+		{"Redis", "", false},
+		{"Database", "", false},
+	} {
+		if v, ok := features.Cfg(data.key); ok != data.exist || v != data.expect {
+			t.Errorf("key: %s expect: %s exist: %t got v: %s ok: %t", data.key, data.expect, data.exist, v, ok)
+		}
+	}
+	for exp, res := range map[string]bool{
+		"Sms":           false,
+		"Sms = SmsJuhe": false,
+		"SmsJuhe":       false,
+		"default":       false,
+		"develop":       true,
+	} {
+		if ok := features.CfgIf(exp); res != ok {
+			t.Errorf("CfgIf(%s) want %t got %t", exp, res, ok)
+		}
+	}
+
+	features.UseDefault()
+	features.Use([]string{"slim", "", "demo"}, false)
+	for _, data := range []struct {
+		key    string
+		expect string
+		exist  bool
+	}{
+		{"Sms", "SmsJuhe", true},
+		{"Alipay", "", true},
+		{"Zinc", "", true},
+		{"Redis", "", true},
+		{"Database", "", false},
+		{"demo", "", true},
+	} {
+		if v, ok := features.Cfg(data.key); ok != data.exist || v != data.expect {
+			t.Errorf("key: %s expect: %s exist: %t got v: %s ok: %t", data.key, data.expect, data.exist, v, ok)
+		}
+	}
+	for exp, res := range map[string]bool{
+		"Sms":           true,
+		"Sms = SmsJuhe": true,
+		"SmsJuhe":       false,
+		"default":       true,
+		"develop":       false,
+		"slim":          true,
+		"demo":          true,
 	} {
 		if ok := features.CfgIf(exp); res != ok {
 			t.Errorf("CfgIf(%s) want %t got %t", exp, res, ok)

--- a/pkg/setting/settting.go
+++ b/pkg/setting/settting.go
@@ -12,11 +12,6 @@ type Setting struct {
 	vp *viper.Viper
 }
 
-type LogType string
-
-const LogFileType LogType = "file"
-const LogZincType LogType = "zinc"
-
 type LoggerFileSettingS struct {
 	SavePath string
 	FileName string
@@ -28,17 +23,6 @@ type LoggerZincSettingS struct {
 	Index    string
 	User     string
 	Password string
-}
-
-type LoggerSettingS struct {
-	LogType         LogType
-	LogFileSavePath string
-	LogFileName     string
-	LogFileExt      string
-	LogZincHost     string
-	LogZincIndex    string
-	LogZincUser     string
-	LogZincPassword string
 }
 
 type ServerSettingS struct {
@@ -82,20 +66,6 @@ type ZincSettingS struct {
 	Index    string
 	User     string
 	Password string
-}
-
-type DatabaseSettingS struct {
-	DBType       string
-	UserName     string
-	Password     string
-	Host         string
-	DBName       string
-	TablePrefix  string
-	Charset      string
-	ParseTime    bool
-	LogLevel     logger.LogLevel
-	MaxIdleConns int
-	MaxOpenConns int
 }
 
 type MySQLSettingS struct {
@@ -192,25 +162,28 @@ func (s *Setting) FeaturesFrom(k string) *FeaturesSettingS {
 
 func newFeatures(suites map[string][]string, kv map[string]string) *FeaturesSettingS {
 	features := &FeaturesSettingS{
-		suites: suites,
-		kv:     kv,
+		suites:   suites,
+		kv:       kv,
+		features: make(map[string]string),
 	}
 	features.UseDefault()
 	return features
 }
 
 func (f *FeaturesSettingS) UseDefault() {
-	defaultSuite := f.suites["default"]
-	f.Use(defaultSuite, true)
+	f.Use([]string{"default"}, true)
 }
 
 func (f *FeaturesSettingS) Use(suite []string, noDefault bool) error {
-	if noDefault {
+	if noDefault && len(f.features) != 0 {
 		f.features = make(map[string]string)
 	}
 	features := f.flatFeatures(suite)
 	for _, feature := range features {
 		feature = strings.ToLower(feature)
+		if len(feature) == 0 {
+			continue
+		}
 		f.features[feature] = f.kv[feature]
 	}
 	return nil


### PR DESCRIPTION
* optimize #62 add command-line support for custom features

usage like:
```
%> ./dist/paopao-ce_darwin_amd64 -h             
Usage of ./dist/paopao-ce_darwin_amd64:
  -features value
        use special features
  -no-default-features
        whether use default features

%> ./dist/paopao-ce_darwin_amd64 -no-default-features -features slim

%>./dist/paopao-ce_darwin_amd64 --no-default-features --features slim --features sms

%>./dist/paopao-ce_darwin_amd64 --no-default-features --features develop,sms

%>./dist/paopao-ce_darwin_amd64 --features sms

```
