### PR TITLE
ipv6本地地址上传图片报错

### DIFF
--- a/pkg/util/iploc/iploc.go
+++ b/pkg/util/iploc/iploc.go
@@ -21,7 +21,12 @@ const (
 
 // Find get country and city base ip
 func Find(ip string) (string, string) {
-	offset := searchIndex(binary.BigEndian.Uint32(net.ParseIP(ip).To4()))
+	// If ip is "::1", To4 returns nil.
+	to4 := net.ParseIP(ip).To4()
+	if to4 == nil {
+		to4 = net.ParseIP("127.0.0.1").To4()
+	}
+	offset := searchIndex(binary.BigEndian.Uint32(to4))
 	if offset <= 0 {
 		return "", ""
 	}


### PR DESCRIPTION
当ip为ipv6本地地址时，`net.ParseIP(ip).To4()`返回nil，然后`binary.BigEndian.Uint32(nil)`会报错。
所以，应该考虑nil的情况