### PR TITLE
web: just reload home path after create post success

### DIFF
--- a/web/src/views/Home.vue
+++ b/web/src/views/Home.vue
@@ -84,12 +84,9 @@ const loadPosts = () => {
 };
 
 const onPostSuccess = (post: Item.PostProps) => {
-    router.push({
-        name: 'post',
-        query: {
-            id: post.id,
-        },
-    });
+    setTimeout(() => {
+        loadPosts();
+    }, 50);
 };
 
 const updatePage = (p: number) => {


### PR DESCRIPTION
* web: just reload home path after create post success

pr概述：
在泡泡广场页面 成功创建推文后，页面跳转到泡泡详情页面，然后从泡泡详情页面返回到广场页面(点按页面中的返回上一级按钮或直接浏览器的返回按钮)，文章列表并没有自动刷新到最新状态，需要额外的刷新操作才能更新文章列表。 用户应该期望的是返回到广场页面后文章列表能自动刷新到最新状态； 这里有两种改法：   
1.  从泡泡详情页面返回到泡泡广场页面后自动刷新文章列表到最新状态；
2. 创建推文后，直接重新加载文章列表到最新状态，不自动跳转到泡泡详情页面；

pr特性：
如上所述，这个pr采用第二种方案解决上述问题。 
* 不太清楚设计之初为什么要在创建推文成功后跳转到泡泡详情页面，但是从我个人使用体验，每次创建推文后，第一件事是顺手返回到泡泡广场页面，因为刚创建的推文泡泡详情页面除了推文内容，啥也没有（点赞/收藏/评论）并不想在这个页面多待，所以在想是不是成功创建推文后留在泡泡广场页面会更好一点呢，这个pr基于这一点优化上述问题。 

* 如果设计需要在创建推文成功后跳转到泡泡详情页，这个pr就不要合并了，可以采用上述第一种方案另外提一个PR优化用户体验。
