### PR TITLE
fixed persist object failed error in localoss oss:tempdir implement

### DIFF
--- a/internal/dao/storage/localoss.go
+++ b/internal/dao/storage/localoss.go
@@ -102,10 +102,7 @@ func (s *localossCreateTempDirServant) PutObject(objectKey string, reader io.Rea
 
 func (s *localossCreateTempDirServant) PersistObject(objectKey string) error {
 	fi, err := os.Stat(s.savePath + objectKey)
-	if err != nil {
-		return err
-	}
-	if !fi.IsDir() {
+	if err == nil && !fi.IsDir() {
 		logrus.Debugf("object exist so do nothing objectKey: %s", objectKey)
 		return nil
 	}


### PR DESCRIPTION
* feature[oss:tempdir]  fixed persist object failed error in localoss implement

just bugfix for oss:tempdir feature in localoss implement.