### PR TITLE
fixed cache index not expire in delete/add tweet error

### DIFF
--- a/internal/dao/cache/base.go
+++ b/internal/dao/cache/base.go
@@ -181,7 +181,7 @@ func (s *cacheIndexSrv) deleteCacheByUserId(id int64, oneself bool) {
 	}
 	for _, key := range allKeys {
 		keyParts := strings.Split(key, ":")
-		if len(keyParts) > 2 && keyParts[0] == "index" {
+		if len(keyParts) > 2 && keyParts[0] == _cacheIndexKey {
 			if _, ok := friendSet[keyParts[1]]; ok {
 				keys = append(keys, key)
 			}


### PR DESCRIPTION
* fixed cache index not expire in delete/add tweet error

pr特性：
* 修复广场推文列表缓存在添加删除推文后没有立即失效的问题，这会导致让用户以为添加/删除推文不成功的错觉，这个bug是之前引入`RedisCacheIndex`功能项时一个小失误导致的，这个补丁用于修复这个bug。
> 这个bug对用户体验影响很大，算是比较严重的bug。